### PR TITLE
Create attachments from data option + other minor changes

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -19,6 +19,17 @@ get '/default' => sub {
     $self->render_file( filepath => $FILE );
 };
 
+get '/data' => sub {
+    my $self = shift;
+    $self->render_file( data => 'data to download', filename => 'sample.txt' );
+};
+
+
+get '/data/no_filename' => sub {
+    my $self = shift;
+    $self->render_file( data => 'data to download' );
+};
+
 get '/all_attrs' => sub {
     my $self = shift;
     $self->render_file( filepath => $FILE, filename => 'mysample.txt', status => 201 );
@@ -29,28 +40,52 @@ my $t = Test::Mojo->new;
 $t->get_ok('/default')
     ->status_is(200)
     ->content_is('file to download')
-    ->content_type_is('application/x-download;name=sample.txt')
-    ->header_is( 'Content-Disposition' => 'attachment;filename=sample.txt' );
+    ->content_type_is('application/x-download;name="sample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="sample.txt"' );
 
 $t->get_ok('/all_attrs')
     ->status_is(201)
     ->content_is('file to download')
-    ->content_type_is('application/x-download;name=mysample.txt')
-    ->header_is( 'Content-Disposition' => 'attachment;filename=mysample.txt' );
+    ->content_type_is('application/x-download;name="mysample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="mysample.txt"' );
 
 $t->get_ok('/default' => { 'Range' => 'bytes=5-' })
     ->status_is(206)
     ->content_is('to download')
-    ->content_type_is('application/x-download;name=sample.txt')
-    ->header_is( 'Content-Disposition' => 'attachment;filename=sample.txt' );
+    ->content_type_is('application/x-download;name="sample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="sample.txt"' );
 
 $t->get_ok('/default' => { 'Range' => 'bytes=5-6' })
     ->status_is(206)
     ->content_is('to')
-    ->content_type_is('application/x-download;name=sample.txt')
-    ->header_is( 'Content-Disposition' => 'attachment;filename=sample.txt' );
+    ->content_type_is('application/x-download;name="sample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="sample.txt"' );
 
 $t->get_ok('/default' => { 'Range' => 'bytes=17-3' })
     ->status_is(416);
+
+$t->get_ok('/data')
+    ->status_is(200)
+    ->content_is('data to download')
+    ->content_type_is('application/x-download;name="sample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="sample.txt"' );
+
+$t->get_ok('/data' => { 'Range' => 'bytes=5-' })
+    ->status_is(206)
+    ->content_is('to download')
+    ->content_type_is('application/x-download;name="sample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="sample.txt"' );
+
+$t->get_ok('/data' => { 'Range' => 'bytes=5-6' })
+    ->status_is(206)
+    ->content_is('to')
+    ->content_type_is('application/x-download;name="sample.txt"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="sample.txt"' );
+
+$t->get_ok('/data/no_filename')
+    ->status_is(200)
+    ->content_is('data to download')
+    ->content_type_is('application/x-download;name="no_filename"')
+    ->header_is( 'Content-Disposition' => 'attachment;filename="no_filename"' );
 
 done_testing();


### PR DESCRIPTION
I have an app that's creating attachments from MongoDB/GridFS. I wanted to use your plugin for this but it doesn't work with this scenario as there's no path to a file -just data, so I added a "data" option.

I also removed some redundant and superfluous method calls and quote the filename in the Content-XXX headers. 

Also see:
https://github.com/sshaw/Mojolicious-Plugin-RenderFile/commit/ca441d66e9cdfe6a5754c8144ab6da9a951b9c7a#commitcomment-1495095

And: 
https://github.com/koorchik/Mojolicious-Plugin-RenderFile/commit/5acf954f3598d6bf56718667156771bbe14a0843#commitcomment-1495628
