### PR TITLE
Fix multibyte filename test for Mojolicious 5.78

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ WriteMakefile(
     VERSION_FROM     => 'lib/Mojolicious/Plugin/RenderFile.pm',
     AUTHOR           => 'Viktor Turskyi <koorchik@cpan.org>',
     MIN_PERL_VERSION => 5.010,
-    PREREQ_PM        => { 'Mojolicious' => '3.90' },
+    PREREQ_PM        => { 'Mojolicious' => '5.78' },
     META_MERGE       => {
         resources => {
             repository => 'https://github.com/koorchik/Mojolicious-Plugin-RenderFile',

--- a/t/multibyte_filename.t
+++ b/t/multibyte_filename.t
@@ -1,3 +1,4 @@
+use utf8;
 use Mojo::Base -strict;
 
 use Test::More;
@@ -51,7 +52,7 @@ my $t = Test::Mojo->new;
 
 $t->get_ok("/default")
     ->status_is(200)
-    ->content_is( encode_utf8 '漢字（かんじ）は、古代中国に発祥を持つ文字。' )
+    ->content_is( '漢字（かんじ）は、古代中国に発祥を持つ文字。' )
     ->header_is( 'Content-Disposition' => encode_utf8 'attachment;filename="漢字.txt"' );
 
 $t->get_ok("/filename")


### PR DESCRIPTION
From Mojolicious 5.78~, `Mojo::Message::text()` tries to decode content using charset of content or `default_charset`. So `Test::Mojo->content_is()` method already decodes its content as 'UTF-8'. So we have to compare string which is not encoded but decoded.

https://github.com/kraih/mojo/commit/32be807217c93e662ef443e7bdb7ecb053596481